### PR TITLE
getStaticPathsのfallbackを'blocking'に変更

### DIFF
--- a/src/pages/posts/[postId].jsx
+++ b/src/pages/posts/[postId].jsx
@@ -61,7 +61,7 @@ const Post = (props) => {
   );
 };
 
-Post.displayName = 'Post';
+Post.displayName = "Post";
 
 export default Post;
 
@@ -80,7 +80,7 @@ export const getStaticPaths = async () => {
 
   // path:事前ビルドするパスの対象を指定するパラメータ
   // fallback:事前ビルドしたパス以外にアクセスした時のパラメータ true:カスタム404pageを表示 false:404pageを表示
-  return { paths, fallback: false };
+  return { paths, fallback: 'blocking' };
 };
 
 // paramsには上記pathsで指定した値が1postずつ入る


### PR DESCRIPTION
## 実装内容
- 以下の記事を参考にfallback: 'blocking'と修正

[https://qiita.com/thesugar/items/47ec3d243d00ddd0b4ed#%E3%83%95%E3%82%A9%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF](https://qiita.com/thesugar/items/47ec3d243d00ddd0b4ed#%E3%83%95%E3%82%A9%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF)